### PR TITLE
Changed the logstash config's output block and fixed #2

### DIFF
--- a/config/logstash.conf
+++ b/config/logstash.conf
@@ -75,6 +75,8 @@ filter {
 }
 
 output {
-  elasticsearch { host => ["localhost:9200"] }
+  elasticsearch { host => localhost
+                  cluster => elasticsearch
+		  protocol => http }
   stdout { codec => rubydebug }
 }


### PR DESCRIPTION
There have been logstash changes in 1.5.5 that broke the output block for Elasticsearch. This was fixed by using the cluster name and the http protocol. 
